### PR TITLE
Add Github Pages URL to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ This repository contains slides for the JS workshop for Anima.
 
 The material is presented using [reveal.js](https://revealjs.com/), a HTML presentation framework.
 
+You can visit [this site](https://rootstrap.github.io/workshop-js-anima) to access all the published content.
+
 ## Installation
 
 1. Clone this repository.

--- a/index.html
+++ b/index.html
@@ -32,9 +32,6 @@
             <li>
               <a href="classes/4.html">Clase 4</a>
             </li>
-            <li class="disabled">
-              Clase 5
-            </li>
           </ul>
         </section>
       </div>


### PR DESCRIPTION
This PR adds Github Pages url to the README with all the content and removes unused link to class 5.